### PR TITLE
Improve loading screen timing

### DIFF
--- a/css/sections/_loader.css
+++ b/css/sections/_loader.css
@@ -1,0 +1,34 @@
+#loading-screen {
+  position: fixed;
+  inset: 0;
+  background: black;
+  display: none;
+  grid-template-columns: repeat(auto-fill, 40px);
+  grid-auto-rows: 40px;
+  z-index: 10000;
+  overflow: hidden;
+}
+
+#loading-screen .loading-tile {
+  width: 40px;
+  height: 40px;
+  background-image: url('../../assets/img/x.svg');
+  background-size: contain;
+  background-repeat: no-repeat;
+  animation: loader-spin 2s linear infinite;
+  margin: 0;
+
+}
+
+#loading-screen.hide {
+  opacity: 0;
+  transition: opacity 0.5s ease;
+}
+
+@keyframes loader-spin {
+  to { transform: rotate(360deg); }
+}
+
+#loading-screen .loading-tile.offset {
+  transform: translateX(20px);
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -7,3 +7,5 @@
 @import url('./sections/_footer.css');
 @import url('./sections/_plyr.css');
 @import url('./sections/_backtotop.css');
+
+@import url('./sections/_loader.css');

--- a/index.html
+++ b/index.html
@@ -5,7 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <title>Rocío Gastaldi | Directora y Productora Audiovisual</title>
   <meta name="description" content="Portfolio oficial de Rocío Gastaldi. Videos comerciales, videoclips y proyectos personales. Directora y productora audiovisual.">
-  <script src="https://unpkg.com/feather-icons"></script>
+  <link rel="preconnect" href="https://unpkg.com">
+  <link rel="preconnect" href="https://cdn.plyr.io">
+  <link rel="preload" href="fonts/SuisseIntl-SemiBold.otf" as="font" type="font/otf" crossorigin>
+  <script defer src="https://unpkg.com/feather-icons"></script>
   <link rel="stylesheet" href="https://cdn.plyr.io/3.7.8/plyr.css" />
   <link rel="stylesheet" href="css/styles.css">
   <link rel="icon" type="image/x-icon" href="assets/img/favicon.png">
@@ -16,6 +19,7 @@
   <meta name="twitter:card" content="summary_large_image">
 </head>
 <body>
+  <div id="loading-screen"></div>
 <nav class="main-nav">
   <div class="logo">ROCIO GASTALDI</div>
   <div class="nav-right">
@@ -62,8 +66,8 @@
 </div>
 <footer id="footer" class="footer">
   <section id="about" class="about-section">
-    <video class="about-bg-video" autoplay muted loop playsinline>
-      <source src="assets/img/about/about2.mp4" type="video/mp4" />
+    <video class="about-bg-video" autoplay muted loop playsinline preload="none">
+      <source data-src="assets/img/about/about2.mp4" type="video/mp4" />
       Tu navegador no soporta videos HTML5.
     </video>
     <div class="about-content">
@@ -79,7 +83,7 @@
             <i data-feather="mail"></i>
           </a>
           <a href="https://vimeo.com/rociogastaldi" target="_blank" title="Vimeo">
-            <img src="assets/img/icons/vimeo.svg" alt="Vimeo" class="vimeo-icon" />
+            <img src="assets/img/icons/vimeo.svg" alt="Vimeo" class="vimeo-icon" loading="lazy" />
           </a>
         </div>
       </div>
@@ -90,7 +94,7 @@
   </section>
 </footer>
 <div id="project-tooltip" class="tooltip"></div>
-<script src="https://cdn.plyr.io/3.7.8/plyr.polyfilled.js"></script>
+<script defer src="https://cdn.plyr.io/3.7.8/plyr.polyfilled.js"></script>
 <script>
   document.getElementById("year").textContent = new Date().getFullYear();
 </script>
@@ -100,3 +104,4 @@
 </button>
 </body>
 </html>
+

--- a/js/_lazyload.js
+++ b/js/_lazyload.js
@@ -1,0 +1,45 @@
+// _lazyload.js
+export function loadProjectMedia(project) {
+  const video = project.querySelector('video[data-src]');
+  if (video && !video.src) {
+    video.src = video.dataset.src;
+  }
+  const hoverVideo = project.querySelector('video.hover-media[data-src]');
+  if (hoverVideo && !hoverVideo.src) {
+    hoverVideo.src = hoverVideo.dataset.src;
+  }
+  const bg = project.querySelector('.bg-image[data-bg]');
+  if (bg && !bg.style.backgroundImage) {
+    bg.style.backgroundImage = `url('${bg.dataset.bg}')`;
+  }
+  const hoverBg = project.querySelector('.hover-media[data-bg]');
+  if (hoverBg && !hoverBg.style.backgroundImage) {
+    hoverBg.style.backgroundImage = `url('${hoverBg.dataset.bg}')`;
+  }
+}
+
+export function initLazyMedia() {
+  const projectObserver = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        loadProjectMedia(entry.target);
+        projectObserver.unobserve(entry.target);
+      }
+    });
+  }, { rootMargin: '200px 0px' });
+
+  document.querySelectorAll('.project').forEach(p => projectObserver.observe(p));
+
+  const aboutSource = document.querySelector('.about-bg-video source[data-src]');
+  if (aboutSource) {
+    const aboutObserver = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting) {
+        aboutSource.src = aboutSource.dataset.src;
+        aboutSource.parentElement.load();
+        aboutObserver.unobserve(entries[0].target);
+      }
+    }, { rootMargin: '200px 0px' });
+    aboutObserver.observe(aboutSource.parentElement);
+  }
+}
+

--- a/js/_loadProjects.js
+++ b/js/_loadProjects.js
@@ -1,29 +1,23 @@
 // _loadProjects.js
 export async function cargarProyectos(callback) {
-  const res = await fetch('./data/proyectos.json');
-  const data = await res.json();
-  window.PROYECTOS = data;
-  callback(data);
-}
+  const response = await fetch('./data/proyectos.json');
+  const proyectos = await response.json();
+  window.PROYECTOS = proyectos;
 
-async function loadProjects() {
-const container = document.getElementById("projects-container");
-const response = await fetch("./data/proyectos.json");
-const proyectos = await response.json();
-
-container.innerHTML = proyectos.map((proyecto, index) => {
-    const mainIsVideo = proyecto.imagen.endsWith(".mp4");
-    const hoverIsVideo = proyecto.imagenHover && proyecto.imagenHover.endsWith(".mp4");
+  const container = document.getElementById('projects-container');
+  container.innerHTML = proyectos.map((proyecto, index) => {
+    const mainIsVideo = proyecto.imagen.endsWith('.mp4');
+    const hoverIsVideo = proyecto.imagenHover && proyecto.imagenHover.endsWith('.mp4');
 
     const media = mainIsVideo
-    ? `<video src="${proyecto.imagen}" autoplay muted loop playsinline></video>`
-    : `<div class="bg-image" style="background-image: url('${proyecto.imagen}')"></div>`;
+      ? `<video data-src="${proyecto.imagen}" autoplay muted loop playsinline preload="none"></video>`
+      : `<div class="bg-image" data-bg="${proyecto.imagen}"></div>`;
 
-    let hover = "";
+    let hover = '';
     if (proyecto.imagenHover) {
-    hover = hoverIsVideo
-        ? `<video class="hover-media" src="${proyecto.imagenHover}" autoplay muted loop playsinline></video>`
-        : `<div class="hover-media" style="background-image: url('${proyecto.imagenHover}')"></div>`;
+      hover = hoverIsVideo
+        ? `<video class="hover-media" data-src="${proyecto.imagenHover}" autoplay muted loop playsinline preload="none"></video>`
+        : `<div class="hover-media" data-bg="${proyecto.imagenHover}"></div>`;
     }
 
     return `
@@ -35,11 +29,11 @@ container.innerHTML = proyectos.map((proyecto, index) => {
         </div>
         <div class="overlay-mobile pre-animate">
         <h2>${proyecto.titulo}</h2>
-        ${proyecto.cliente ? `<p>${proyecto.cliente}</p>` : ""}
+        ${proyecto.cliente ? `<p>${proyecto.cliente}</p>` : ''}
         </div>
     </a>
     `;
-}).join("");
-}
+  }).join('');
 
-loadProjects();
+  callback(proyectos);
+}

--- a/js/_loadingScreen.js
+++ b/js/_loadingScreen.js
@@ -1,0 +1,44 @@
+// _loadingScreen.js
+let startTime = 0;
+
+export function showLoadingScreen() {
+  const overlay = document.getElementById('loading-screen');
+  if (!overlay) return;
+
+  startTime = Date.now();
+
+  const size = 40;
+  const cols = Math.ceil(window.innerWidth / size);
+  const rows = Math.ceil(window.innerHeight / size);
+  overlay.style.display = 'grid';
+  overlay.style.gridTemplateColumns = `repeat(${cols}, ${size}px)`;
+  overlay.style.gridAutoRows = `${size}px`;
+
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      const tile = document.createElement('div');
+      tile.className = 'loading-tile';
+      if (r % 2) tile.classList.add('offset');
+      tile.style.animationDelay = `${Math.random() * 2}s`;
+      overlay.appendChild(tile);
+    }
+  }
+}
+
+export function hideLoadingScreen() {
+  const overlay = document.getElementById('loading-screen');
+  if (!overlay) return;
+
+  const elapsed = Date.now() - startTime;
+  const minTime = 1200;
+  const finish = () => {
+    overlay.classList.add('hide');
+    setTimeout(() => overlay.remove(), 500);
+  };
+
+  if (elapsed < minTime) {
+    setTimeout(finish, minTime - elapsed);
+  } else {
+    finish();
+  }
+}

--- a/js/script.js
+++ b/js/script.js
@@ -1,18 +1,44 @@
-import './_loadProjects.js'
 import './_modal.js';
 import './_theme.js';
 import { inicializarTooltips } from './_tooltip.js';
 import './_animations.js';
 import { inicializarFiltros } from './_filters.js';
 import './_plyr-init.js';
+import { initLazyMedia, loadProjectMedia } from './_lazyload.js';
 
+import { showLoadingScreen, hideLoadingScreen } from './_loadingScreen.js';
 import { observarProyectos, resetAnimationIndex } from './_animations.js';
 import { cargarProyectos } from './_loadProjects.js';
 import { openModal, closeModal, setProyectos } from './_modal.js';
 
+function preloadInitialMedia(count = 4) {
+  const projects = Array.from(document.querySelectorAll('.project')).slice(0, count);
+  const promises = projects.map(proj => {
+    loadProjectMedia(proj);
+    const video = proj.querySelector('video');
+    if (video) {
+      return new Promise(res => {
+        if (video.readyState >= 2) return res();
+        video.addEventListener('loadeddata', res, { once: true });
+      });
+    }
+    const bg = proj.querySelector('.bg-image');
+    if (bg) {
+      return new Promise(res => {
+        const img = new Image();
+        img.onload = res;
+        img.src = bg.dataset.bg;
+      });
+    }
+    return Promise.resolve();
+  });
+  return Promise.all(promises);
+}
+
 // Ejecutar feather icons y demás scripts cuando el DOM esté listo
 document.addEventListener('DOMContentLoaded', () => {
   if (typeof feather !== 'undefined') feather.replace();
+  showLoadingScreen();
 
   const backToTopBtn = document.getElementById("back-to-top");
 
@@ -29,7 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // Cargar proyectos y exponer funciones globales
-  cargarProyectos((data) => {
+  cargarProyectos(async (data) => {
     setProyectos(data);
     window.openModal = openModal;
     window.closeModal = closeModal;
@@ -38,5 +64,10 @@ document.addEventListener('DOMContentLoaded', () => {
     inicializarFiltros();
     resetAnimationIndex();
     observarProyectos();
+    initLazyMedia();
+    await preloadInitialMedia(4);
+    hideLoadingScreen();
   });
 });
+
+

--- a/js/script.js
+++ b/js/script.js
@@ -1,15 +1,13 @@
-import './_modal.js';
+import { openModal, closeModal, setProyectos } from './_modal.js';
 import './_theme.js';
 import { inicializarTooltips } from './_tooltip.js';
-import './_animations.js';
+import { observarProyectos, resetAnimationIndex } from './_animations.js';
 import { inicializarFiltros } from './_filters.js';
 import './_plyr-init.js';
 import { initLazyMedia, loadProjectMedia } from './_lazyload.js';
 
 import { showLoadingScreen, hideLoadingScreen } from './_loadingScreen.js';
-import { observarProyectos, resetAnimationIndex } from './_animations.js';
 import { cargarProyectos } from './_loadProjects.js';
-import { openModal, closeModal, setProyectos } from './_modal.js';
 
 function preloadInitialMedia(count = 4) {
   const projects = Array.from(document.querySelectorAll('.project')).slice(0, count);


### PR DESCRIPTION
## Summary
- keep loader visible for at least 1.2s
- expose `loadProjectMedia` utility and preload first projects
- wait for initial media to load before hiding loader

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a2a5cf724832188b1f6a4a8bc79c5