### PR TITLE
Add spinning X loading screen

### DIFF
--- a/css/sections/_loading.css
+++ b/css/sections/_loading.css
@@ -1,0 +1,40 @@
+#loading-screen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: black;
+  z-index: 10000;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  pointer-events: none;
+  transition: opacity 0.5s ease;
+}
+
+#loading-screen.hidden {
+  opacity: 0;
+}
+
+.loader-row {
+  display: flex;
+  flex-shrink: 0;
+  height: 40px;
+}
+
+.loader-row.offset {
+  padding-left: 20px;
+}
+
+.loader-icon {
+  width: 40px;
+  height: 40px;
+  flex: 0 0 40px;
+  animation: loader-spin 3s linear infinite;
+}
+
+@keyframes loader-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -7,3 +7,4 @@
 @import url('./sections/_footer.css');
 @import url('./sections/_plyr.css');
 @import url('./sections/_backtotop.css');
+@import url('./sections/_loading.css');

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
   <meta name="twitter:card" content="summary_large_image">
 </head>
 <body>
+<div id="loading-screen"></div>
 <nav class="main-nav">
   <div class="logo">ROCIO GASTALDI</div>
   <div class="nav-right">

--- a/js/_loadingScreen.js
+++ b/js/_loadingScreen.js
@@ -1,0 +1,64 @@
+export function initLoadingScreen() {
+  const loader = document.getElementById('loading-screen');
+  if (!loader) return;
+  const size = 40;
+  const cols = Math.ceil(window.innerWidth / size) + 1;
+  const rows = Math.ceil(window.innerHeight / size);
+
+  for (let r = 0; r < rows; r++) {
+    const row = document.createElement('div');
+    row.className = 'loader-row' + (r % 2 ? ' offset' : '');
+    for (let c = 0; c < cols; c++) {
+      const img = document.createElement('img');
+      img.src = 'assets/img/x.svg';
+      img.className = 'loader-icon';
+      row.appendChild(img);
+    }
+    loader.appendChild(row);
+  }
+
+  // Fallback hide after 10s
+  setTimeout(hideLoadingScreen, 10000);
+}
+
+export function hideLoadingScreen() {
+  const loader = document.getElementById('loading-screen');
+  if (loader && !loader.classList.contains('hidden')) {
+    loader.classList.add('hidden');
+    setTimeout(() => loader.remove(), 500);
+  }
+}
+
+export function monitorFirstProjects(count) {
+  const projects = document.querySelectorAll('.project');
+  const targets = Array.from(projects).slice(0, count);
+  if (targets.length === 0) {
+    hideLoadingScreen();
+    return;
+  }
+  let remaining = targets.length;
+
+  targets.forEach(proj => {
+    const video = proj.querySelector('video');
+    const bg = proj.querySelector('.bg-image');
+
+    if (video) {
+      if (video.readyState >= 2) check();
+      else video.addEventListener('loadeddata', check, { once: true });
+    } else if (bg) {
+      const url = bg.style.backgroundImage || `url('${bg.dataset.bg}')`;
+      const match = url.match(/url\(["']?(.*?)["']?\)/);
+      const src = match ? match[1] : bg.dataset.bg;
+      const img = new Image();
+      img.onload = check;
+      img.src = src;
+    } else {
+      check();
+    }
+  });
+
+  function check() {
+    remaining--;
+    if (remaining <= 0) hideLoadingScreen();
+  }
+}

--- a/js/script.js
+++ b/js/script.js
@@ -6,6 +6,7 @@ import './_animations.js';
 import { inicializarFiltros } from './_filters.js';
 import './_plyr-init.js';
 import { initLazyMedia } from './_lazyload.js';
+import { initLoadingScreen, monitorFirstProjects } from './_loadingScreen.js';
 
 import { observarProyectos, resetAnimationIndex } from './_animations.js';
 import { cargarProyectos } from './_loadProjects.js';
@@ -14,6 +15,8 @@ import { openModal, closeModal, setProyectos } from './_modal.js';
 // Ejecutar feather icons y demás scripts cuando el DOM esté listo
 document.addEventListener('DOMContentLoaded', () => {
   if (typeof feather !== 'undefined') feather.replace();
+
+  initLoadingScreen();
 
   const backToTopBtn = document.getElementById("back-to-top");
 
@@ -40,6 +43,7 @@ document.addEventListener('DOMContentLoaded', () => {
     resetAnimationIndex();
     observarProyectos();
     initLazyMedia();
+    monitorFirstProjects(12);
   });
 });
 


### PR DESCRIPTION
## Summary
- create a loader screen overlay
- generate a brick-wall grid of X icons that spin
- hide the loader once the first rows of projects load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a3696266c8321bb57a2d8fe3ba004