### PR TITLE
Add loader text overlay

### DIFF
--- a/css/sections/_loading.css
+++ b/css/sections/_loading.css
@@ -38,3 +38,14 @@
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
+
+.loader-text {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: white;
+  font-size: clamp(1.5rem, 8vw, 3rem);
+  pointer-events: none;
+  z-index: 1;
+}

--- a/css/sections/_loading.css
+++ b/css/sections/_loading.css
@@ -48,4 +48,15 @@
   font-size: clamp(1.5rem, 8vw, 3rem);
   pointer-events: none;
   z-index: 1;
+  text-shadow: 0 0 10px rgba(0, 0, 0, 0.8);
+  animation: loader-text-pulse 2s ease-in-out infinite;
+}
+
+@keyframes loader-text-pulse {
+  0%, 100% {
+    opacity: 0.8;
+  }
+  50% {
+    opacity: 1;
+  }
 }

--- a/js/_loadingScreen.js
+++ b/js/_loadingScreen.js
@@ -17,6 +17,11 @@ export function initLoadingScreen() {
     loader.appendChild(row);
   }
 
+  const text = document.createElement('div');
+  text.className = 'loader-text';
+  text.textContent = 'ROCIO GASTALDI';
+  loader.appendChild(text);
+
   // Fallback hide after 10s
   setTimeout(hideLoadingScreen, 10000);
 }


### PR DESCRIPTION
## Summary
- add `loader-text` element overlay via JS
- style `loader-text` to appear centered on the loading screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a3ed6553883218e34168d8069d307