### PR TITLE
Initialize tooltips after loading screen hides

### DIFF
--- a/js/_loadingScreen.js
+++ b/js/_loadingScreen.js
@@ -30,7 +30,12 @@ export function hideLoadingScreen() {
   const loader = document.getElementById('loading-screen');
   if (loader && !loader.classList.contains('hidden')) {
     loader.classList.add('hidden');
-    setTimeout(() => loader.remove(), 500);
+    setTimeout(() => {
+      loader.remove();
+      document.dispatchEvent(new Event('loadingScreenHidden'));
+    }, 500);
+  } else {
+    document.dispatchEvent(new Event('loadingScreenHidden'));
   }
 }
 

--- a/js/script.js
+++ b/js/script.js
@@ -32,13 +32,14 @@ document.addEventListener('DOMContentLoaded', () => {
     window.scrollTo({ top: 0, behavior: "smooth" });
   });
 
+  // Iniciar tooltips cuando desaparezca la pantalla de carga
+  document.addEventListener('loadingScreenHidden', inicializarTooltips, { once: true });
+
   // Cargar proyectos y exponer funciones globales
   cargarProyectos((data) => {
     setProyectos(data);
     window.openModal = openModal;
     window.closeModal = closeModal;
-    // ⚡ Activar tooltips ahora que los proyectos están cargados
-    inicializarTooltips();
     inicializarFiltros();
     resetAnimationIndex();
     observarProyectos();


### PR DESCRIPTION
## Summary
- fire a `loadingScreenHidden` event when the loader finishes
- listen for `loadingScreenHidden` and start tooltips at that point

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a62c56fe88321a3ffd402e720e194