### PR TITLE
Improve loading screen performance

### DIFF
--- a/css/sections/_loading.css
+++ b/css/sections/_loading.css
@@ -17,27 +17,6 @@
   opacity: 0;
 }
 
-.loader-row {
-  display: flex;
-  flex-shrink: 0;
-  height: 40px;
-}
-
-.loader-row.offset {
-  padding-left: 20px;
-}
-
-.loader-icon {
-  width: 40px;
-  height: 40px;
-  flex: 0 0 40px;
-  animation: loader-spin 3s linear infinite;
-}
-
-@keyframes loader-spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
 
 .loader-text {
   position: absolute;

--- a/js/_loadingScreen.js
+++ b/js/_loadingScreen.js
@@ -1,21 +1,9 @@
 export function initLoadingScreen() {
   const loader = document.getElementById('loading-screen');
   if (!loader) return;
-  const size = 40;
-  const cols = Math.ceil(window.innerWidth / size) + 1;
-  const rows = Math.ceil(window.innerHeight / size);
-
-  for (let r = 0; r < rows; r++) {
-    const row = document.createElement('div');
-    row.className = 'loader-row' + (r % 2 ? ' offset' : '');
-    for (let c = 0; c < cols; c++) {
-      const img = document.createElement('img');
-      img.src = 'assets/img/x.svg';
-      img.className = 'loader-icon';
-      row.appendChild(img);
-    }
-    loader.appendChild(row);
-  }
+  loader.style.backgroundImage = "url('assets/img/x.svg')";
+  loader.style.backgroundRepeat = 'repeat';
+  loader.style.backgroundSize = '40px 40px';
 
   const text = document.createElement('div');
   text.className = 'loader-text';


### PR DESCRIPTION
## Summary
- simplify loading screen rendering by using a single repeated background image
- remove unused loader element styles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688a6938ec5c83219ccd62577deeadc6