### PR TITLE
Fix mobile grid widths

### DIFF
--- a/css/sections/_projects.css
+++ b/css/sections/_projects.css
@@ -82,11 +82,11 @@
       grid-template-columns: repeat(2, 1fr); /* 2 columnas en móviles */
     }
 
-    .project-1-1 {
+    .project-1-1,
+    .project-1-2 {
       grid-column: span 2; /* Ocupar el ancho completo */
     }
 
-    .project-1-2,
     .project-1-4 {
       grid-column: span 1; /* Mitad del ancho */
     }

--- a/css/sections/_projects.css
+++ b/css/sections/_projects.css
@@ -79,15 +79,18 @@
   
   @media (max-width: 600px) {
     .projects-grid {
-      grid-template-columns: 1fr; /* 1 columna en móviles */
+      grid-template-columns: repeat(2, 1fr); /* 2 columnas en móviles */
     }
-  
-    .project-1-1,
+
+    .project-1-1 {
+      grid-column: span 2; /* Ocupar el ancho completo */
+    }
+
     .project-1-2,
     .project-1-4 {
-      grid-column: span 1;
+      grid-column: span 1; /* Mitad del ancho */
     }
-  
+
     .project {
       height: 50vw; /* Más alta en pantallas chicas */
     }


### PR DESCRIPTION
## Summary
- adjust mobile grid for projects so `1/1` items span two columns and `1/2` or `1/4` items span one column

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a8297e3a88321b52cdca7ccae3d9a