### PR TITLE
Remove background video from about section

### DIFF
--- a/css/sections/_footer.css
+++ b/css/sections/_footer.css
@@ -1,6 +1,7 @@
 .about-section {
   position: relative;
-  min-height: 100vh;
+  min-height: 70vh;
+  background-color: black;
   color: white;
   display: flex;
   align-items: center;
@@ -9,16 +10,6 @@
   overflow: hidden;
 }
 
-.about-bg-video {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  z-index: -1;
-  filter: brightness(0.5);
-}
 
 .about-content {
   max-width: 800px;

--- a/index.html
+++ b/index.html
@@ -62,10 +62,6 @@
 </div>
 <footer id="footer" class="footer">
   <section id="about" class="about-section">
-    <video class="about-bg-video" autoplay muted loop playsinline>
-      <source src="assets/img/about/about2.mp4" type="video/mp4" />
-      Tu navegador no soporta videos HTML5.
-    </video>
     <div class="about-content">
       <h2>ROCIO GASTALDI</h2>
       <p>Directora y productora audiovisual con base en Buenos Aires.<br>Trabaja en videoclips, comerciales, escenografía y shows en vivo.</p>


### PR DESCRIPTION
## Summary
- drop the video element in the About footer section
- shrink and restyle the about section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b798bc8bc8321a91ff6244360a7ff