### PR TITLE
Skip loader when cached

### DIFF
--- a/js/_loadingScreen.js
+++ b/js/_loadingScreen.js
@@ -32,6 +32,29 @@ export function hideLoadingScreen() {
   }
 }
 
+export function resourcesLoadedFromCache(urls) {
+  const entries = performance.getEntriesByType('resource');
+  return urls.every(u => {
+    try {
+      const abs = new URL(u, location.href).href;
+      const entry = entries.find(e => e.name === abs);
+      return entry && entry.transferSize === 0;
+    } catch {
+      return false;
+    }
+  });
+}
+
+export function shouldSkipLoadingScreen(projects) {
+  const urls = [];
+  projects.forEach(p => {
+    if (p.imagen) urls.push(p.imagen);
+    if (p.imagenHover) urls.push(p.imagenHover);
+  });
+  if (urls.length === 0) return false;
+  return resourcesLoadedFromCache(urls);
+}
+
 export function monitorFirstProjects(count) {
   const projects = document.querySelectorAll('.project');
   const targets = Array.from(projects).slice(0, count);

--- a/js/script.js
+++ b/js/script.js
@@ -6,7 +6,7 @@ import './_animations.js';
 import { inicializarFiltros } from './_filters.js';
 import './_plyr-init.js';
 import { initLazyMedia } from './_lazyload.js';
-import { initLoadingScreen, monitorFirstProjects } from './_loadingScreen.js';
+import { initLoadingScreen, monitorFirstProjects, shouldSkipLoadingScreen, hideLoadingScreen } from './_loadingScreen.js';
 
 import { observarProyectos, resetAnimationIndex } from './_animations.js';
 import { cargarProyectos } from './_loadProjects.js';
@@ -44,7 +44,12 @@ document.addEventListener('DOMContentLoaded', () => {
     resetAnimationIndex();
     observarProyectos();
     initLazyMedia();
-    monitorFirstProjects(5);
+    const firstFive = data.slice(0, 5);
+    if (shouldSkipLoadingScreen(firstFive)) {
+      hideLoadingScreen();
+    } else {
+      monitorFirstProjects(5);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- detect if preloaded project assets came from cache
- hide loading screen when assets are cached

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b9419ffe083218d56b873dd77d10f