### PR TITLE
Optimize navbar color updates

### DIFF
--- a/js/_theme.js
+++ b/js/_theme.js
@@ -6,10 +6,11 @@ document.addEventListener("DOMContentLoaded", () => {
   const mainNav = document.querySelector('.main-nav');
   const projects = document.getElementById('projects-container');
 
+  let navHeight = mainNav ? mainNav.offsetHeight : 0;
+  let threshold = projects ? projects.offsetTop - navHeight : 0;
+
   function updateNavbarColor() {
     const isLight = body.classList.contains('bg-white');
-    const navHeight = mainNav ? mainNav.offsetHeight : 0;
-    const threshold = projects ? projects.offsetTop - navHeight : 0;
     if (isLight && window.scrollY >= threshold) {
       body.classList.add('nav-white');
     } else {
@@ -17,10 +18,16 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
+  window.addEventListener('resize', () => {
+    navHeight = mainNav ? mainNav.offsetHeight : 0;
+    threshold = projects ? projects.offsetTop - navHeight : 0;
+    updateNavbarColor();
+  });
+
   let currentTheme = localStorage.getItem("theme") || "white";
   applyTheme(currentTheme);
   updateNavbarColor();
-  window.addEventListener('scroll', updateNavbarColor);
+  window.addEventListener('scroll', updateNavbarColor, { passive: true });
 
   themeBtn.addEventListener("click", () => {
     let nextIndex = (themes.indexOf(currentTheme) + 1) % themes.length;


### PR DESCRIPTION
## Summary
- cache navbar height and project offset to avoid recalculating on scroll
- use passive scroll listeners and update cached values on resize

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689256ab73208321b7c06b6d071f8795